### PR TITLE
Optimizations, invalid memory fix, console color restore

### DIFF
--- a/plugin/src/Gothic/CMusicSys_Bass.hpp
+++ b/plugin/src/Gothic/CMusicSys_Bass.hpp
@@ -4,7 +4,7 @@ namespace GOTHIC_NAMESPACE
 	{
 		void Event_OnEnd(const NH::Bass::MusicDef& musicDef, int data, void* userData)
 		{
-			NH::Log::Debug("Event", Union::StringUTF8("Event_OnEnd: ") + Union::StringUTF8(musicDef.Filename.ToChar()));
+			NH::Log::Debug("Event", Union::StringUTF8("Event_OnEnd: ") + musicDef.Filename);
 
 			zSTRING filename{ musicDef.Filename.ToChar() };
 			zSTRING name{ musicDef.Name.ToChar() };
@@ -20,7 +20,7 @@ namespace GOTHIC_NAMESPACE
 
 		void Event_OnTransition(const NH::Bass::MusicDef& musicDef, int data, void* userData)
 		{
-			NH::Log::Debug("Event", Union::StringUTF8("Event_OnTransition: ") + Union::StringUTF8(musicDef.Filename.ToChar())
+			NH::Log::Debug("Event", Union::StringUTF8("Event_OnTransition: ") + musicDef.Filename
 				+ Union::StringUTF8::Format(", %i ms", data));
 
 			zSTRING filename{ musicDef.Filename.ToChar() };
@@ -102,7 +102,7 @@ namespace GOTHIC_NAMESPACE
 				return nullptr;
 			}
 
-			NH::Log::Info("CMusicSys_Bass", Union::StringUTF8::Format("LoadThemeByScript: ") + id.ToChar());
+			NH::Log::Info("CMusicSys_Bass", Union::StringUTF8("LoadThemeByScript: ") + id.ToChar());
 
 			zSTRING identifier = id;
 			if (m_ActiveTheme && identifier.Upper() == m_ActiveTheme->name)
@@ -135,7 +135,7 @@ namespace GOTHIC_NAMESPACE
 					NH::Bass::MusicFile& musicFileRef = m_BassEngine->CreateMusicBuffer(theme->fileName.ToChar());
 					if (!musicFileRef.Ready && !musicFileRef.Loading)
 					{
-						NH::Log::Info("CMusicSys_Bass", Union::StringUTF8::Format("Loading music: ") + file->GetFullPath().ToChar());
+						NH::Log::Info("CMusicSys_Bass", Union::StringUTF8("Loading music: ") + file->GetFullPath().ToChar());
 
 						file->Open(false);
 						musicFileRef.Loading = true;
@@ -161,7 +161,7 @@ namespace GOTHIC_NAMESPACE
 				}
 				else
 				{
-					NH::Log::Error("CMusicSys_Bass", Union::StringUTF8::Format("Could not find file: ") + theme->fileName.ToChar());
+					NH::Log::Error("CMusicSys_Bass", Union::StringUTF8("Could not find file: ") + theme->fileName.ToChar());
 				}
 			}
 
@@ -175,11 +175,11 @@ namespace GOTHIC_NAMESPACE
 				return;
 			}
 
-			NH::Log::Info("CMusicSys_Bass", Union::StringUTF8::Format("PlayThemeByScript: ") + id.ToChar());
+			NH::Log::Info("CMusicSys_Bass", Union::StringUTF8("PlayThemeByScript: ") + id.ToChar());
 
 			if (Globals->FullScriptControl)
 			{
-				NH::Log::Info("CMusicSys_Bass", Union::StringUTF8::Format("PlayThemeByScript skipped because FullScriptControl is enabled."));
+				NH::Log::Info("CMusicSys_Bass", Union::StringUTF8("PlayThemeByScript skipped because FullScriptControl is enabled."));
 				return;
 			}
 

--- a/plugin/src/Gothic/CMusicSys_Bass.hpp
+++ b/plugin/src/Gothic/CMusicSys_Bass.hpp
@@ -97,7 +97,7 @@ namespace GOTHIC_NAMESPACE
 
 		zCMusicTheme* LoadThemeByScript(zSTRING const& id) override
 		{
-			if (s_musicSystemDisabled || !id || id.IsEmpty())
+			if (s_musicSystemDisabled || id.IsEmpty())
 			{
 				return nullptr;
 			}
@@ -170,7 +170,7 @@ namespace GOTHIC_NAMESPACE
 
 		void PlayThemeByScript(zSTRING const& id, int manipulate, int* done) override
 		{
-			if (s_musicSystemDisabled || !id || id.IsEmpty())
+			if (s_musicSystemDisabled || id.IsEmpty())
 			{
 				return;
 			}

--- a/plugin/src/Gothic/Options.hpp
+++ b/plugin/src/Gothic/Options.hpp
@@ -24,10 +24,10 @@ namespace GOTHIC_NAMESPACE
 		NH::Bass::Options->TransitionTime = zoptions->ReadReal("BASSMUSIC", "TransitionTime", 2000.0f);
 		NH::Log::Info("ApplyOptions", Union::StringUTF8("TransitionTime = ") + Union::StringUTF8(NH::Bass::Options->TransitionTime));
 		NH::Bass::Options->ForceDisableReverb = zoptions->ReadBool("BASSMUSIC", "ForceDisableReverb", false);
-		NH::Log::Info("ApplyOptions", Union::StringUTF8("ForceDisableReverb = ") + Union::StringUTF8(NH::Bass::Options->ForceDisableReverb ? "TRUE" : "FALSE"));
+		NH::Log::Info("ApplyOptions", Union::StringUTF8("ForceDisableReverb = ") + (NH::Bass::Options->ForceDisableReverb ? "TRUE" : "FALSE"));
 		NH::Bass::Options->ForceFadeTransition = zoptions->ReadBool("BASSMUSIC", "ForceFadeTransition", false);
-		NH::Log::Info("ApplyOptions", Union::StringUTF8("ForceFadeTransition = ") + Union::StringUTF8(NH::Bass::Options->ForceFadeTransition ? "TRUE" : "FALSE"));
+		NH::Log::Info("ApplyOptions", Union::StringUTF8("ForceFadeTransition = ") + (NH::Bass::Options->ForceFadeTransition ? "TRUE" : "FALSE"));
 		NH::Bass::Options->CreateMainParserCMusicTheme = zoptions->ReadBool("BASSMUSIC", "CreateMainParserCMusicTheme", true);
-		NH::Log::Info("ApplyOptions", Union::StringUTF8("CreateMainParserCMusicTheme = ") + Union::StringUTF8(NH::Bass::Options->CreateMainParserCMusicTheme ? "TRUE" : "FALSE"));
+		NH::Log::Info("ApplyOptions", Union::StringUTF8("CreateMainParserCMusicTheme = ") + (NH::Bass::Options->CreateMainParserCMusicTheme ? "TRUE" : "FALSE"));
 	}
 }

--- a/plugin/src/Gothic/Options.hpp
+++ b/plugin/src/Gothic/Options.hpp
@@ -11,13 +11,13 @@ namespace GOTHIC_NAMESPACE
 
 
 		{
-			char* value = zoptions->ReadString("BASSMUSIC", "LoggerLevelUnion", "INFO").ToChar();
-			NH::Bass::Options->LoggerLevelUnion = Union::StringUTF8(value);
+			zSTRING value = zoptions->ReadString("BASSMUSIC", "LoggerLevelUnion", "INFO");
+			NH::Bass::Options->LoggerLevelUnion = Union::StringUTF8(value.ToChar());
 			NH::Log::Info("ApplyOptions", Union::StringUTF8("LoggerLevelUnion = ") + NH::Bass::Options->LoggerLevelUnion);
 		}
 		{
-			char* value = zoptions->ReadString("BASSMUSIC", "LoggerLevelZSpy", "DEBUG").ToChar();
-			NH::Bass::Options->LoggerLevelZSpy = Union::StringUTF8(value);
+			zSTRING value = zoptions->ReadString("BASSMUSIC", "LoggerLevelZSpy", "DEBUG");
+			NH::Bass::Options->LoggerLevelZSpy = Union::StringUTF8(value.ToChar());
 			NH::Log::Info("ApplyOptions", Union::StringUTF8("LoggerLevelZSpy = ") + NH::Bass::Options->LoggerLevelZSpy);
 		}
 

--- a/plugin/src/NH/Bass.cpp
+++ b/plugin/src/NH/Bass.cpp
@@ -20,9 +20,8 @@ namespace NH
 
 		MusicFile& Engine::CreateMusicBuffer(const Union::StringUTF8& filename)
 		{
-			for (size_t i = 0; i < m_MusicFiles.GetCount(); i++)
+			for (auto& m : m_MusicFiles)
 			{
-				MusicFile& m = m_MusicFiles[i];
 				if (m.Filename == filename) {
 					Log::Info("BassEngine", Union::StringUTF8("CreateMusicBuffer: Buffer already exists for ") + filename);
 					return m;
@@ -199,25 +198,27 @@ namespace NH
 
 		MusicFile* Engine::GetMusicFile(const Union::StringUTF8& filename)
 		{
-			for (int i = 0; i < m_MusicFiles.GetCount(); i++)
+			for(auto& m : m_MusicFiles)
 			{
-				if (m_MusicFiles[i].Filename == filename)
+				if (m.Filename == filename)
 				{
-					return &m_MusicFiles[i];
+					return &m;
 				}
 			}
+
 			return nullptr;
 		}
 
 		Channel* Engine::FindAvailableChannel()
 		{
-			for (int i = 0; i < m_Channels.size(); i++)
+			for (auto& channel : m_Channels)
 			{
-				if (m_Channels[i].IsAvailable())
+				if (channel.IsAvailable())
 				{
-					return &m_Channels[i];
+					return &channel;
 				}
 			}
+
 			return nullptr;
 		}
 

--- a/plugin/src/NH/Bass.cpp
+++ b/plugin/src/NH/Bass.cpp
@@ -194,8 +194,8 @@ namespace NH
 			BASS_GetInfo(&info);
 			Log::Info("BassEngine", Union::StringUTF8("BASS Sample Rate: ") + Union::StringUTF8(info.freq) + Union::StringUTF8(" Hz"));
 
-			constexpr size_t Channels_Max = 8;
-			m_Channels.resize(8, Channel{m_EventManager});
+			static constexpr size_t Channels_Max = 8;
+			m_Channels.resize(Channels_Max, Channel{m_EventManager});
 		}
 
 		MusicFile* Engine::GetMusicFile(const Union::StringUTF8& filename)

--- a/plugin/src/NH/Bass.cpp
+++ b/plugin/src/NH/Bass.cpp
@@ -168,10 +168,10 @@ namespace NH
 				bool enabled = deviceInfo.flags & BASS_DEVICE_ENABLED;
 				bool isDefault = deviceInfo.flags & BASS_DEVICE_DEFAULT;
 
-				Log::Info("BassEngine", Union::StringUTF8("Available device: ") + deviceInfo.name 
+				Log::Info("BassEngine", Union::StringUTF8("Available device: ") + deviceInfo.name
 					+ Union::StringUTF8(", driver: ") + deviceInfo.driver
-					+ Union::StringUTF8(", enabled: ") + Union::StringUTF8(enabled ? "true" : "faqlse")
-					+ Union::StringUTF8(", default: ") + Union::StringUTF8(isDefault ? "true" : "faqlse"));
+					+ Union::StringUTF8(", enabled: ") + Union::StringUTF8(enabled ? "true" : "false")
+					+ Union::StringUTF8(", default: ") + Union::StringUTF8(isDefault ? "true" : "false"));
 
 				if (enabled && isDefault)
 				{
@@ -194,14 +194,8 @@ namespace NH
 			BASS_GetInfo(&info);
 			Log::Info("BassEngine", Union::StringUTF8("BASS Sample Rate: ") + Union::StringUTF8(info.freq) + Union::StringUTF8(" Hz"));
 
-			m_Channels.emplace_back(Channel(m_EventManager));
-			m_Channels.emplace_back(Channel(m_EventManager));
-			m_Channels.emplace_back(Channel(m_EventManager));
-			m_Channels.emplace_back(Channel(m_EventManager));
-			m_Channels.emplace_back(Channel(m_EventManager));
-			m_Channels.emplace_back(Channel(m_EventManager));
-			m_Channels.emplace_back(Channel(m_EventManager));
-			m_Channels.emplace_back(Channel(m_EventManager));
+			constexpr size_t Channels_Max = 8;
+			m_Channels.resize(8, Channel{m_EventManager});
 		}
 
 		MusicFile* Engine::GetMusicFile(const Union::StringUTF8& filename)

--- a/plugin/src/NH/Bass.cpp
+++ b/plugin/src/NH/Bass.cpp
@@ -95,13 +95,12 @@ namespace NH
 			uint64_t delta = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastTimestamp).count();
 			lastTimestamp = now;
 
-			for (size_t i = 0; i < m_PlayMusicRetryList.size(); i++)
+			for(auto& retry : m_PlayMusicRetryList)
 			{
-				MusicDefRetry& retry = m_PlayMusicRetryList[i];
 				retry.delayMs -= delta;
 				if (retry.delayMs < 0)
 				{
-					Log::Debug("BassEngine", Union::StringUTF8("PlayMusic retry: ") + Union::StringUTF8(retry.musicDef.Filename));
+					Log::Debug("BassEngine", Union::StringUTF8("PlayMusic retry: ") + retry.musicDef.Filename);
 					PlayMusic(retry.musicDef);
 				}
 			}

--- a/plugin/src/NH/Bass.cpp
+++ b/plugin/src/NH/Bass.cpp
@@ -168,9 +168,9 @@ namespace NH
 				bool isDefault = deviceInfo.flags & BASS_DEVICE_DEFAULT;
 
 				Log::Info("BassEngine", Union::StringUTF8("Available device: ") + deviceInfo.name
-					+ Union::StringUTF8(", driver: ") + deviceInfo.driver
-					+ Union::StringUTF8(", enabled: ") + Union::StringUTF8(enabled ? "true" : "false")
-					+ Union::StringUTF8(", default: ") + Union::StringUTF8(isDefault ? "true" : "false"));
+					+ ", driver: "   + deviceInfo.driver
+					+ ", enabled: "  + (enabled ? "true" : "false")
+					+ ", default: "  + (isDefault ? "true" : "false"));
 
 				if (enabled && isDefault)
 				{

--- a/plugin/src/NH/Bass.cpp
+++ b/plugin/src/NH/Bass.cpp
@@ -104,7 +104,7 @@ namespace NH
 					PlayMusic(retry.musicDef);
 				}
 			}
-			std::erase_if(m_PlayMusicRetryList, [](MusicDefRetry retry) { return retry.delayMs < 0; });
+			std::erase_if(m_PlayMusicRetryList, [](const MusicDefRetry& retry) { return retry.delayMs < 0; });
 
 			BASS_Update(delta);
 

--- a/plugin/src/NH/BassEventManager.cpp
+++ b/plugin/src/NH/BassEventManager.cpp
@@ -13,11 +13,11 @@ namespace NH
 
 		void EventManager::RemoveSubscriber(const EventSubscriber* subscriber)
 		{
-			for (auto s : m_Subscribers)
+			for (const auto i : std::views::iota(0u, m_Subscribers.GetCount()) | std::views::reverse)
 			{
-				if (&s == subscriber)
+				if (&m_Subscribers[i] == subscriber)
 				{
-					m_Subscribers.Remove(s);
+					m_Subscribers.RemoveAt(i);
 				}
 			}
 		}

--- a/plugin/src/NH/BassEventManager.cpp
+++ b/plugin/src/NH/BassEventManager.cpp
@@ -34,7 +34,7 @@ namespace NH
 				NH::Log::Debug("EM", Union::StringUTF8("Processing events, left: ") + Union::StringUTF8(m_EventQueue.size()));
 				Event event = m_EventQueue.back();
 				m_EventQueue.pop_back();
-				for (const auto s : m_Subscribers)
+				for (const auto& s : m_Subscribers)
 				{
 					if (s.Type == event.type)
 					{

--- a/plugin/src/NH/BassEventManager.cpp
+++ b/plugin/src/NH/BassEventManager.cpp
@@ -22,7 +22,7 @@ namespace NH
 			}
 		}
 
-		void EventManager::DispatchEvent(const EventType type, const MusicDef musicDef, const int data)
+		void EventManager::DispatchEvent(const EventType type, const MusicDef& musicDef, const int data)
 		{
 			m_EventQueue.emplace_front(Event{type, musicDef, data});
 		}

--- a/plugin/src/NH/BassEventManager.h
+++ b/plugin/src/NH/BassEventManager.h
@@ -8,7 +8,7 @@ namespace NH
 {
 	namespace Bass
 	{
-		using EventSubscriberFunction = void(*)(const MusicDef, int data, void*);
+		using EventSubscriberFunction = void(*)(const MusicDef&, int data, void*);
 
 		enum class EventType
 		{
@@ -51,7 +51,7 @@ namespace NH
 
 			void RemoveSubscriber(const EventSubscriber* subscriber);
 
-			void DispatchEvent(EventType type, const MusicDef musicDef, int data = 0);
+			void DispatchEvent(EventType type, const MusicDef& musicDef, int data = 0);
 
 			void Update();
 

--- a/plugin/src/NH/Union.cpp
+++ b/plugin/src/NH/Union.cpp
@@ -7,9 +7,9 @@ namespace NH
 	namespace Log
 	{
 
-		inline bool ShouldLog(Level level, Union::StringUTF8 config)
+		inline bool ShouldLog(Level level, const Union::StringUTF8& config)
 		{
-			if (!config)
+			if (config.IsEmpty())
 			{
 				return true;
 			}
@@ -20,9 +20,9 @@ namespace NH
 			return false;
 		}
 
-		void Message(Level level, Union::StringUTF8 channel, Union::StringUTF8 message)
+		void Message(Level level, const Union::StringUTF8& channel, const Union::StringUTF8& message)
 		{
-			if (ShouldLog(level, NH::Bass::Options->LoggerLevelUnion)) {
+			if (ShouldLog(level, NH::Bass::Options->LoggerLevelUnion)) {		
 				Union::StringUTF8 output = "";
 				switch (level)
 				{
@@ -45,13 +45,13 @@ namespace NH
 			if (ShouldLog(level, NH::Bass::Options->LoggerLevelZSpy)) {
 				if (GetGameVersion() == Engine_G1)
 				{
-					auto msg = Gothic_I_Classic::zSTRING("B:\tBASSMUSIC: ") + Gothic_I_Classic::zSTRING(channel.ToChar()) + Gothic_I_Classic::zSTRING(": ") + Gothic_I_Classic::zSTRING(message.ToChar());
+					auto msg = Gothic_I_Classic::zSTRING("B:\tBASSMUSIC: ") + channel.ToChar() + ": " + message.ToChar();
 					Gothic_I_Classic::zerr->Message(msg);
 				}
 
 				if (GetGameVersion() == Engine_G2A)
 				{
-					auto msg = Gothic_II_Addon::zSTRING("B:\tBASSMUSIC: ") + Gothic_II_Addon::zSTRING(channel.ToChar()) + Gothic_II_Addon::zSTRING(": ") + Gothic_II_Addon::zSTRING(message.ToChar());
+					auto msg = Gothic_II_Addon::zSTRING("B:\tBASSMUSIC: ") + channel.ToChar() + ": " + message.ToChar();
 					Gothic_II_Addon::zerr->Message(msg);
 				}
 			}

--- a/plugin/src/NH/Union.cpp
+++ b/plugin/src/NH/Union.cpp
@@ -39,7 +39,7 @@ namespace NH
 					output = Union::StringUTF8::Format("\x1B[1m\x1B[97m\x1B[41mzBassMusic ERROR \x1B[0m\x1B[91m %s: %s", channel, message);
 					break;
 				}
-				
+ 
 				const auto handle = GetStdHandle(STD_OUTPUT_HANDLE);
 				CONSOLE_SCREEN_BUFFER_INFO consoleInfo;
 				GetConsoleScreenBufferInfo(handle, &consoleInfo);
@@ -47,6 +47,8 @@ namespace NH
 
 				DWORD dw;
 				WriteConsoleA(handle, output.ToChar(), output.GetLength(), &dw, nullptr);
+				static constexpr std::string_view newLine{"\n"};
+				WriteConsoleA(handle, newLine.data(), newLine.size(), &dw, nullptr);
 
 				SetConsoleTextAttribute(handle, color);
 			}

--- a/plugin/src/NH/Union.cpp
+++ b/plugin/src/NH/Union.cpp
@@ -39,7 +39,16 @@ namespace NH
 					output = Union::StringUTF8::Format("\x1B[1m\x1B[97m\x1B[41mzBassMusic ERROR \x1B[0m\x1B[91m %s: %s", channel, message);
 					break;
 				}
-				output.StdPrintLine();
+				
+				const auto handle = GetStdHandle(STD_OUTPUT_HANDLE);
+				CONSOLE_SCREEN_BUFFER_INFO consoleInfo;
+				GetConsoleScreenBufferInfo(handle, &consoleInfo);
+				const auto color = consoleInfo.wAttributes;
+
+				DWORD dw;
+				WriteConsoleA(handle, output.ToChar(), output.GetLength(), &dw, nullptr);
+
+				SetConsoleTextAttribute(handle, color);
 			}
 
 			if (ShouldLog(level, NH::Bass::Options->LoggerLevelZSpy)) {

--- a/plugin/src/NH/Union.h
+++ b/plugin/src/NH/Union.h
@@ -17,7 +17,7 @@ namespace NH
 			ERROR = 3
 		};
 
-		void Message(Level level, Union::StringUTF8 channel, Union::StringUTF8 message);
+		void Message(Level level, const Union::StringUTF8& channel, const Union::StringUTF8& message);
 
 		inline void Debug(const Union::StringUTF8& channel, const Union::StringUTF8& message) { Message(Level::DEBUG, channel, message); }
 		inline void Debug(const Union::StringUTF8& message) { Debug("DEFAULT", message); }


### PR DESCRIPTION
This PR includes:
1. Changed copying of extensive types such as NH::Bass::MusicDef, Union::StringUTF8 to be taken as references, for optimization
2. Fix with using deleted or invalid memory:
- when reading log type (using char* from destroyed string)
- when deleting subscriber (for range loop is not valid for random deleting elements in array)
3. Restoring the console color after the log
4. Optimalizations of creating strings and channels.
5. Removed copying of subscribers in EventManager::Update
6. Removed signed and unsigned compare int in for loops


A few suggestions:
- Don't copy the back of m_EventQueue in EventManager::Update (make it moveable and move, or pop at the end of the loop after iterating from 0 to size-1). You can also use smart pointers for events.
- Change logging function to take string_view or don't require allocating of string to create argument to concentrate const char* to string.
- Try not to mix containers and strings from different APIs unless necessary. You are using zCArray, std::vector, Union::Array, std::deque, Union::StringUTF8, etc. at the same time, it is better to use types from one API if possible.
I know that we can't eliminate usage of the classes from engine, but this should be used efficient too and in some cases we should use only zClasses instead of std/Union or vice versa.
- Add 4 level warnings in Cmake