### PR TITLE
Load file leak fix

### DIFF
--- a/plugin/src/Gothic/CMusicSys_Bass.hpp
+++ b/plugin/src/Gothic/CMusicSys_Bass.hpp
@@ -142,9 +142,7 @@ namespace GOTHIC_NAMESPACE
 						{
 							musicFileRef.Loading = true;
 
-							std::thread([](std::unique_ptr<zFILE> myFile, NH::Bass::MusicFile* myMusicPtr) {
-								
-								auto loadingStart = std::chrono::system_clock::now();
+							std::thread([loadingStart = std::chrono::system_clock::now()](std::unique_ptr<zFILE> myFile, NH::Bass::MusicFile* myMusicPtr) {
 
 								zSTRING path = myFile->GetFullPath();
 								const long size = myFile->Size();

--- a/plugin/src/Gothic/CMusicSys_Bass.hpp
+++ b/plugin/src/Gothic/CMusicSys_Bass.hpp
@@ -110,26 +110,25 @@ namespace GOTHIC_NAMESPACE
 				return m_ActiveTheme;
 			}
 
-			zCMusicTheme* theme = zNEW(zCMusicTheme);
-			if (NH::Bass::Options->CreateMainParserCMusicTheme && parser->GetSymbol(identifier) != nullptr)
+			zCMusicTheme* theme = new zCMusicTheme;
+			
+			if (!(NH::Bass::Options->CreateMainParserCMusicTheme && parser->CreateInstance(identifier, &theme->fileName)))
 			{
-				parser->CreateInstance(identifier, (void*)(&(theme->fileName)));
+				parserMusic->CreateInstance(identifier, &theme->fileName);
 			}
-			else
-			{
-				parserMusic->CreateInstance(identifier, (void*)(&(theme->fileName)));
-			}
-			theme->name = identifier;
 
 			if (IsDirectMusicFormat(theme->fileName))
 			{
-				zDELETE(theme);
+				delete theme;
 				theme = m_DirectMusic->LoadThemeByScript(id);
 			}
 			else
 			{
+				theme->name = identifier;
+
 				zoptions->ChangeDir(DIR_MUSIC);
-				zFILE* file = zfactory->CreateZFile(theme->fileName);
+				std::unique_ptr<zFILE> file{ zfactory->CreateZFile(theme->fileName) };
+
 				if (file->Exists())
 				{
 					NH::Bass::MusicFile& musicFileRef = m_BassEngine->CreateMusicBuffer(theme->fileName.ToChar());
@@ -137,26 +136,39 @@ namespace GOTHIC_NAMESPACE
 					{
 						NH::Log::Info("CMusicSys_Bass", Union::StringUTF8("Loading music: ") + file->GetFullPath().ToChar());
 
-						file->Open(false);
-						musicFileRef.Loading = true;
-						auto loadingStart = std::chrono::system_clock::now();
+						const auto error = file->Open(false);
 
-						std::thread loadingThread([file, &musicFileRef, loadingStart]() {
-							size_t size = file->Size();
-							musicFileRef.Buffer.resize(size);
-							size_t read = file->Read(musicFileRef.Buffer.data(), size);
-							file->Close();
+						if (error == 0)
+						{
+							musicFileRef.Loading = true;
 
-							musicFileRef.Ready = true;
-							musicFileRef.Loading = false;
-
-							uint64_t loadingTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - loadingStart).count();
+							std::thread([loadingStart = std::chrono::system_clock::now(), myFile = std::move(file), &musicFileRef]() {
 								
-							NH::Log::Info("CMusicSys_Bass", Union::StringUTF8::Format("%z ready, size ", file->GetFullPath()) + Union::StringUTF8(read));
-							NH::Log::Debug("CMusicSys_Bass", Union::StringUTF8::Format("%z loading took %I ms", file->GetFullPath(), loadingTime));
-						});
+								zSTRING path = myFile->GetFullPath();
+								const long size = myFile->Size();
+								
+								musicFileRef.Buffer.resize(static_cast<size_t>(size));
+								const long read = myFile->Read(musicFileRef.Buffer.data(), size);
 
-						loadingThread.detach();
+								if (read == size)
+								{
+									musicFileRef.Ready = true;
+
+									NH::Log::Info("CMusicSys_Bass", Union::StringUTF8::Format("%z ready, size ", path) + Union::StringUTF8(read));
+								}
+
+								musicFileRef.Loading = false;
+								myFile->Close();
+											
+								auto loadingTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - loadingStart).count();
+
+								NH::Log::Debug("CMusicSys_Bass", Union::StringUTF8::Format("%z loading took %I ms", path, loadingTime));
+							}).detach();
+						}
+						else
+						{
+							NH::Log::Error("CMusicSys_Bass", Union::StringUTF8("Could not open file: ") + theme->fileName.ToChar());
+						}
 					}
 				}
 				else


### PR DESCRIPTION
This PR simplifies creating instance of zCMusicTheme* and fixes the memory leak on every time music file was loaded in CMusicSys_Bass::LoadThemeByScript.
Files created by zCFactory::CreateZFile should be deleted, so I replaced the raw ptr with a unique_ptr which is moved to a new thread when the file is opened correctly in the main thread.
I also added a check to see if the read byte size is equal to the file size.
I removed call to zCParser::GetSymbol, because zCParser::CreateInstance is checking if the symbol exists and this doesn't make sense to check it twice.