### PR TITLE
bugfix: General Access Violation caused by too short lifetime of MusicDef

### DIFF
--- a/plugin/src/NH/Bass.h
+++ b/plugin/src/NH/Bass.h
@@ -5,9 +5,11 @@
 #include <NH/BassChannel.h>
 #include <NH/BassTransitionScheduler.h>
 #include <NH/Logger.h>
+#include <NH/HashString.h>
 #include <vector>
 #include <mutex>
 #include <chrono>
+#include <unordered_map>
 
 namespace NH
 {
@@ -24,6 +26,7 @@ namespace NH
 			Channel* m_ActiveChannel = nullptr;
 			EventManager m_EventManager{};
             TransitionScheduler m_TransitionScheduler{};
+			std::unordered_map<HashString, MusicDef> m_MusicDefs;
 
 			std::mutex m_PlayMusicMutex;
 			std::vector<MusicDefRetry> m_PlayMusicRetryList;
@@ -33,7 +36,7 @@ namespace NH
 
 			MusicFile& CreateMusicBuffer(const Union::StringUTF8& filename);
 
-			void PlayMusic(const MusicDef& musicDef);
+			void PlayMusic(MusicDef musicDef);
 
 			void Update();
 

--- a/plugin/src/NH/BassTypes.h
+++ b/plugin/src/NH/BassTypes.h
@@ -41,6 +41,17 @@ namespace NH
 				float ReverbMix = 0.0f;
 				float ReverbTime = 1000.0f;
 			} Effects{};
+
+			void CopyFrom(const MusicDef& other)
+			{
+				Filename = other.Filename;
+				Name = other.Name;
+				Volume = other.Volume;
+				Loop = other.Loop;
+				StartTransition = other.StartTransition;
+				EndTransition = other.EndTransition;
+				Effects = other.Effects;
+			}
 		};
 
 		struct MusicDefRetry

--- a/plugin/src/NH/HashString.h
+++ b/plugin/src/NH/HashString.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace NH
+{
+	namespace FNV1a
+	{
+        // FNV1a c++11 constexpr compile time hash functions, 32 and 64 bit
+        // str should be a null terminated string literal, value should be left out
+        // e.g hash_32_fnv1a_const("example")
+        // code license: public domain or equivalent
+        // post: https://notes.underscorediscovery.com/constexpr-fnv1a/
+        constexpr uint32_t val_32_const = 0x811c9dc5;
+        constexpr uint32_t prime_32_const = 0x1000193;
+        constexpr uint64_t val_64_const = 0xcbf29ce484222325;
+        constexpr uint64_t prime_64_const = 0x100000001b3;
+
+        inline constexpr uint32_t hash_32_fnv1a_const(const char* const str, const uint32_t value = val_32_const) noexcept
+        {
+            return (str[0] == '\0') ? value : hash_32_fnv1a_const(&str[1], (value ^ uint32_t(str[0])) * prime_32_const);
+        }
+
+        inline constexpr uint64_t hash_64_fnv1a_const(const char* const str, const uint64_t value = val_64_const) noexcept
+        {
+            return (str[0] == '\0') ? value : hash_64_fnv1a_const(&str[1], (value ^ uint64_t(str[0])) * prime_64_const);
+        }
+	}
+
+	// HashString is a compile-time 64-bit FNV1a hash of a string literal.
+	// It can be used as a key in hash maps to avoid runtime string comparisons.
+    class HashString
+    {
+        uint64_t Id;
+
+    public:
+		constexpr HashString(const char* str) noexcept : Id(FNV1a::hash_64_fnv1a_const(str)) {}
+		constexpr operator uint64_t() const noexcept { return Id; }
+		constexpr bool operator==(const HashString& other) const noexcept { return Id == other.Id; }
+    };
+
+	constexpr HashString operator"" _hs(const char* str, size_t) noexcept
+	{
+		return HashString(str);
+	}
+}
+
+template<>
+struct std::hash<NH::HashString>
+{
+	std::size_t operator()(const NH::HashString& k) const
+	{
+		return std::hash<uint64_t>()(static_cast<uint64_t>(k));
+	}
+};


### PR DESCRIPTION
`MusicDef` is used to store music themes config, and we need it for the whole lifetime of the application. However, the object was created by `CMusicSys_Bass` on a stack and passed to the `Engine` as a reference. A moment later, the scope of `CMusicSys_Bass` function finished and `MusicDef` was deallocated despite being used by other classes.

This change moves the ownership of `MusicDef` to the `Engine`, so we can guarantee its lifetime.

As a bonus feature, I added `HashString` that can be used for compile-time string hashing (to `uint64_t`) and as an efficient key for hash maps.