### PR TITLE
fix: Read OGG as a direct binary stream to avoid StreamFilterOGG

### DIFF
--- a/src/NH/Bass/MusicTheme.cpp
+++ b/src/NH/Bass/MusicTheme.cpp
@@ -74,7 +74,7 @@ namespace NH::Bass
                         return;
                     }
 
-                    Union::Stream* stream = file->Open();
+                    auto* stream = new Union::FileReader(file->GetFullName());
                     m_AudioFiles[type].Buffer.resize(stream->GetSize());
                     stream->Read(m_AudioFiles[type].Buffer.data(), m_AudioFiles[type].Buffer.size());
                     stream->Close();


### PR DESCRIPTION
Opening the file created a new `Stream` and later the OGG files were loaded using `StreamFilterOGG` that caused problems after trying to play them with Bass. After this change, we are reading the file binary stream directly to get all the bytes unaltered.