### PR TITLE
fix: music looping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
       msvc-toolkit:
         required: false
         type: string
-        default: 14.39
+        default: 14.40
       project-version:
         required: false
         type: string

--- a/src/NH/Bass/Channel.cpp
+++ b/src/NH/Bass/Channel.cpp
@@ -39,6 +39,11 @@ namespace NH::Bass
         BASS_ChannelSetAttribute(m_Stream, BASS_ATTRIB_VOL, volume);
     }
 
+    void Channel::SetLoop(bool loop)
+    {
+        BASS_ChannelFlags(m_Stream, BASS_SAMPLE_LOOP, loop ? BASS_SAMPLE_LOOP : 0);
+    }
+
     void Channel::SlideVolume(float targetVolume, uint32_t time)
     {
         BASS_ChannelSlideAttribute(m_Stream, BASS_ATTRIB_VOL, targetVolume, time);

--- a/src/NH/Bass/Channel.h
+++ b/src/NH/Bass/Channel.h
@@ -25,7 +25,9 @@ namespace NH::Bass
 
         Result<void> PlayInstant(const AudioFile& audioFile) override;
         void StopInstant() override;
+
         void SetVolume(float volume) override;
+        void SetLoop(bool loop) override;
         void SlideVolume(float targetVolume, uint32_t time) override;
         void SlideVolume(float targetVolume, uint32_t time, const std::function<void()>& onFinish) override;
         void SetDX8ReverbEffect(float reverbMix, float reverbTime, float inputGain, float highFreqRTRatio) override;

--- a/src/NH/Bass/IChannel.h
+++ b/src/NH/Bass/IChannel.h
@@ -38,6 +38,7 @@ namespace NH::Bass
         virtual void StopInstant() = 0;
 
         virtual void SetVolume(float volume) = 0;
+        virtual void SetLoop(bool loop) = 0;
         virtual void SlideVolume(float targetVolume, uint32_t time) = 0;
         virtual void SlideVolume(float targetVolume, uint32_t time, const std::function<void()>& onFinish) = 0;
         virtual void SetDX8ReverbEffect(float reverbMix, float reverbTime, float inputGain, float highFreqRTRatio) = 0;

--- a/src/NH/Bass/MusicTheme.cpp
+++ b/src/NH/Bass/MusicTheme.cpp
@@ -125,6 +125,7 @@ namespace NH::Bass
             if (transition.Jingle)
             {
                 auto channel = engine.AcquireFreeChannel();
+                channel->SetLoop(false);
                 auto result = channel->PlayInstant(*transition.Jingle);
                 if (result) { channel->OnAudioEnds(CreateSyncHandler([channel]() { channel->Release(); })); }
                 else
@@ -183,6 +184,8 @@ namespace NH::Bass
             ReleaseChannels();
             return;
         }
+
+        channel->SetLoop(effects.Loop.Active);
 
         if (effects.ReverbDX8.Active)
         {


### PR DESCRIPTION
Add method to set BASS_SAMPLE_LOOP on a Channel, that was lost during Channel refactoring.