### PR TITLE
Implement concurrent access control for Channel::SlideVolume 

### DIFF
--- a/src/NH/Bass/Channel.h
+++ b/src/NH/Bass/Channel.h
@@ -15,6 +15,9 @@ namespace NH::Bass
         Logger* log;
         ChannelStatus m_Status = ChannelStatus::AVAILABLE;
         HSTREAM m_Stream = 0;
+        HSYNC m_CurrentVolumeSlideSync;
+        uint32_t m_CurrentVolumeSlideTime;
+        std::function<void(bool)> m_CurrentVolumeSlideCallback;
 
     public:
         explicit Channel(size_t index)

--- a/src/NH/Bass/MusicTheme.cpp
+++ b/src/NH/Bass/MusicTheme.cpp
@@ -262,7 +262,12 @@ namespace NH::Bass
         {
             const uint32_t time = timePoint.has_value() ? static_cast<uint32_t>(timePoint.value().Duration) * 1000 : static_cast<uint32_t>(transition.EffectDuration);
             log->Trace("Fadeout, time: {0}", time);
-            channel->SlideVolume(0.0f, time, CreateSyncHandler([channel, this]() -> void {
+            channel->SlideVolume(0.0f, time, CreateSyncHandler([channel, this](bool skip = false) -> void {
+                                     if (skip) 
+                                     {
+                                        log->Trace("SlideVolume (fadeout) sync handler skipped without an action because newer fadeout handle took its place");
+                                        return;
+                                     }
                                      log->Trace("Fadeout done");
                                      channel->StopInstant();
                                      ReleaseChannels();

--- a/src/NH/Bass/MusicTheme.h
+++ b/src/NH/Bass/MusicTheme.h
@@ -65,6 +65,7 @@ namespace NH::Bass
         std::unordered_map<std::string, std::shared_ptr<MidiFile>> m_MidiFiles;
         std::unordered_map<size_t, std::function<void()>> m_SyncHandlers;
         std::unordered_map<size_t, std::function<void(double)>> m_SyncHandlersWithDouble;
+        std::unordered_map<size_t, std::function<void(bool)>> m_SyncHandlersWithBoolean;
         std::vector<std::string> m_Zones;
         std::vector<std::shared_ptr<IChannel>> m_AcquiredChannels;
 
@@ -113,6 +114,18 @@ namespace NH::Bass
             };
             m_SyncHandlersWithDouble.emplace(id, std::move(handler));
             return m_SyncHandlersWithDouble.at(id);
+        }
+
+        const std::function<void(bool)>& CreateSyncHandler(std::function<void(bool)>&& function)
+        {
+            size_t id = m_SyncHandlersId++;
+            log->Trace("SyncHandler id: {0}", id);
+            auto handler = [this, function = std::move(function), id](const bool value) {
+                function(value);
+                m_SyncHandlersWithBoolean.erase(id);
+            };
+            m_SyncHandlersWithBoolean.emplace(id, std::move(handler));
+            return m_SyncHandlersWithBoolean.at(id);
         }
 
         const std::function<void()>& CreateSyncHandler(std::function<void()>&& function)


### PR DESCRIPTION
Implement concurrent access control for Channel::SlideVolume  with syn handler as First-In Only-Out strategy. Previous sync handlers that didn't fire are discarded as expired.