### PR TITLE
Throw error when loading .ogg files

### DIFF
--- a/src/NH/Bass/MusicTheme.cpp
+++ b/src/NH/Bass/MusicTheme.cpp
@@ -103,6 +103,10 @@ namespace NH::Bass
                         m_AudioFiles[type].Error = "File not found";
                         return;
                     }
+
+                    // union-api VDFS implements preprocessing for .ogg files to ensure compatibility with the SystemPack,
+                    // which decoded them in a specific way to make this format work with Gothic sound system.
+                    // Therefore the data optained from .ogg files is not raw OGG data and cannot be used directly by BASS
                     if (file->GetName().EndsWith(".OGG"))
                     {
                         m_AudioFiles[type].Status = AudioFile::StatusType::FAILED;
@@ -110,7 +114,6 @@ namespace NH::Bass
                         log->Error("Could not load audio file {0} - {1}", file->GetName(), m_AudioFiles[type].Error.c_str());
                         return;
                     }
-
 
                     auto* stream = file->Open();
                     m_AudioFiles[type].Buffer.resize(stream->GetSize());


### PR DESCRIPTION
As reported in #85 files with `.ogg` extension cannot be played correctly, therefore and error that instructs user to rename the file extension is thrown